### PR TITLE
use location.hostname instead of location.domain

### DIFF
--- a/corslite.js
+++ b/corslite.js
@@ -7,7 +7,7 @@ function corslite(url, callback, cors) {
 
     if (typeof cors === 'undefined') {
         var m = url.match(/^\s*https?:\/\/[^\/]*/);
-        cors = m && (m[0] !== location.protocol + '//' + location.domain +
+        cors = m && (m[0] !== location.protocol + '//' + location.hostname +
                 (location.port ? ':' + location.port : ''));
     }
 


### PR DESCRIPTION
The cors check tries to use `location.domain` which doesn't exist in the location api: https://developer.mozilla.org/en-US/docs/Web/API/Location#Properties .
This will always result in `protocol://undefined:port`.

I'm not 100% sure if the hostname is what you wanted to use, but it returns the `domain of the URL`.