### PR TITLE
[Fixes #14] Improved IE detection

### DIFF
--- a/corslite.js
+++ b/corslite.js
@@ -17,7 +17,7 @@ function corslite(url, callback, cors) {
         return status >= 200 && status < 300 || status === 304;
     }
 
-    if (cors && !('withCredentials' in x)) {
+    if (cors && (typeof window.XDomainRequest != 'undefined')) {
         // IE8-9
         x = new window.XDomainRequest();
 


### PR DESCRIPTION
Using typeof to see if window.XDomainRequest exists will ensure the
library works with XMLHttpRequest intercepting/mocking libraries do not
include `withCredentials` in the created object, eg. Pretender